### PR TITLE
Client-side PP changes

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -560,7 +560,7 @@
 		buf += '</span> ';
 
 		// power, accuracy, pp
-		var pp = (move.pp === 1 || move.noPPBoosts ? move.pp : move.pp * 8 / 5);
+		var pp = (move.pp === 1 || move.noPPBoosts ? move.pp : Math.floor(move.pp * 8 / 5));
 		if (this.engine && this.engine.dex.gen < 3) pp = Math.min(61, pp);
 		buf += '<span class="col labelcol">' + (move.category !== 'Status' ? ('<em>Power</em><br />' + (move.basePower || '&mdash;')) : '') + '</span> ';
 		buf += '<span class="col widelabelcol"><em>Accuracy</em><br />' + (move.accuracy && move.accuracy !== true ? move.accuracy + '%' : '&mdash;') + '</span> ';
@@ -597,7 +597,7 @@
 		buf += '</span> ';
 
 		// power, accuracy, pp
-		var pp = (move.pp === 1 || move.noPPBoosts ? move.pp : move.pp * 8 / 5);
+		var pp = (move.pp === 1 || move.noPPBoosts ? move.pp : Math.floor(move.pp * 8 / 5));
 		if (this.engine && this.engine.dex.gen < 3) pp = Math.min(61, pp);
 		buf += '<span class="col labelcol">' + (move.category !== 'Status' ? ('<em>Power</em><br />' + (move.basePower || '&mdash;')) : '') + '</span> ';
 		buf += '<span class="col widelabelcol"><em>Accuracy</em><br />' + (move.accuracy && move.accuracy !== true ? move.accuracy + '%' : '&mdash;') + '</span> ';
@@ -638,7 +638,7 @@
 		// power, accuracy, pp
 		buf += '<span class="col labelcol">' + (move.category !== 'Status' ? ('<em>Power</em><br />' + (move.basePower || '&mdash;')) : '') + '</span> ';
 		buf += '<span class="col widelabelcol"><em>Accuracy</em><br />' + (move.accuracy && move.accuracy !== true ? move.accuracy + '%' : '&mdash;') + '</span> ';
-		buf += '<span class="col pplabelcol"><em>PP</em><br />' + (move.pp !== 1 ? move.pp * 8 / 5 : move.pp) + '</span> ';
+		buf += '<span class="col pplabelcol"><em>PP</em><br />' + (move.pp !== 1 ? Math.floor(move.pp * 8 / 5) : move.pp) + '</span> ';
 
 		// desc
 		buf += '<span class="col teambuildercol movedesccol">' + BattleLog.escapeHTML(move.shortDesc || move.desc) + '</span> ';

--- a/src/battle-searchresults.tsx
+++ b/src/battle-searchresults.tsx
@@ -186,7 +186,7 @@ class PSSearchResults extends preact.Component<{search: DexSearch}> {
 			</a></li>;
 		}
 
-		let pp = (move.pp === 1 || move.noPPBoosts ? move.pp : move.pp * 8 / 5);
+		let pp = (move.pp === 1 || move.noPPBoosts ? move.pp : Math.floor(move.pp * 8 / 5));
 		if (search.dex.gen < 3) pp = Math.min(61, pp);
 		return <li class="result"><a href={`${this.URL_ROOT}move/${id}`} data-target="push" data-entry={`move|${move.name}`}>
 			<span class="col movenamecol">{this.renderName(move.name, matchStart, matchEnd, tagStart)}</span>

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1482,7 +1482,7 @@ class BattleTooltips {
 			maxpp = 5;
 		} else {
 			move = this.battle.dex.moves.get(moveName);
-			maxpp = (move.pp === 1 || move.noPPBoosts ? move.pp : move.pp * 8 / 5);
+			maxpp = (move.pp === 1 || move.noPPBoosts ? move.pp : Math.floor(move.pp * 8 / 5));
 			if (this.battle.gen < 3) maxpp = Math.min(61, maxpp);
 		}
 		const bullet = moveName.charAt(0) === '*' || move.isZ ? '<span style="color:#888">&#8226;</span>' : '&#8226;';


### PR DESCRIPTION
Moves can now have any PP values without its MaxPP variant turning into a float. This has no impact on existing vanilla/clover moves since the formula "numberdivisibleby5 x 8 / 5" always result into an integer and not a float. It was made so that I could give the proper number of PPs to Wack moves in the future.