### PR TITLE
Bandicute Thicc Bone/Winkhulu Item Displays

### DIFF
--- a/src/battle-animations-moves.ts
+++ b/src/battle-animations-moves.ts
@@ -49271,6 +49271,7 @@ BattleMoveAnims['meddymeds'] = {anim: BattleMoveAnims['dailydose'].anim};
 BattleMoveAnims['bearhug'] = {anim: BattleMoveAnims['bind'].anim};
 BattleMoveAnims['faeblade'] = {anim: BattleMoveAnims['spacialrend'].anim};
 BattleMoveAnims['thunderdrop'] = {anim: BattleMoveAnims['skydrop'].anim};
+BattleMoveAnims['blockbuster'] = {anim: BattleMoveAnims['brickbreak'].anim};
 BattleMoveAnims['potemkinbuster'] = {anim: BattleMoveAnims['skydrop'].anim};
 BattleMoveAnims['garudaimpact'] = {anim: BattleMoveAnims['fireblast'].anim};
 

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1174,9 +1174,17 @@ class BattleTooltips {
 		}
 
 		if (item === 'thiccbone') {
-			if (species === 'Masdawg' || species === 'Pasdawg' || species === 'Naughtycoot') {
+			if (species === 'Masdawg' || species === 'Pasdawg' || species === 'Bandicute' || species === 'Naughtycoot') {
 				stats.atk *= 2;
 			}
+		}
+
+		if (item === 'cursedfang' && species === 'Winkhulu') {
+			stats.atk *= 2;
+		}
+
+		if (item === 'crimsonlens' && species === 'Winkhulu') {
+			stats.spa *= 2;
 		}
 
 		if (item === 'bigfaggot' && species === 'Flameboyan') {


### PR DESCRIPTION
displays the stat changes in the hover tooltip for bandicute using the thicc bone and winkhulu using the cursed fang or crimson lens

side note im calling it rn that someone's gonna see that the stat change isnt displayed in the tooltip when this inevitably doesnt get merged immediately and theyre gonna ask if it actually works or not